### PR TITLE
fix(visual-keyboard): restore heatmap for literal keys

### DIFF
--- a/src/managers/visualKeyboardsManager/visualKeyboardsManager.svelte.ts
+++ b/src/managers/visualKeyboardsManager/visualKeyboardsManager.svelte.ts
@@ -227,6 +227,11 @@ export class VisualKeyboardManager {
       Object.entries(symbolToCode).map(([sym, code]) => [code, sym])
     )
     if (key in codeToSymbol) out.add(codeToSymbol[key])
+    // Letters and digits ↔ code aliases (e.g., 'a' ↔ 'keya', '1' ↔ 'digit1')
+    if (/^[a-z]$/.test(key)) out.add(`key${key}`)
+    if (/^key[a-z]$/.test(key)) out.add(key.slice(3))
+    if (/^[0-9]$/.test(key)) out.add(`digit${key}`)
+    if (/^digit[0-9]$/.test(key)) out.add(key.slice(5))
     return Array.from(out)
   }
 

--- a/tasks/25081003-baked-key-display-names.md
+++ b/tasks/25081003-baked-key-display-names.md
@@ -2,7 +2,7 @@
 title: Baked key display names in search and commands list
 status: in_progress
 owner: "@agent"
-updated: 2025-08-10 14:45 UTC
+updated: 2025-08-10 18:30 UTC
 related:
   - [[25081001-visual-keyboard-keys-and-hover-highlights]]
   - [[25080913-SPRINT-list-of-bugs-and-new-feature-requests]]
@@ -48,6 +48,7 @@ Definition of done:
 - [2025-08-10 17:15 UTC] Introduced platformized modifiers: transform command hotkeys and active modifiers to OS-appropriate forms (Meta→Ctrl on Windows) for rendering and matching. Commands list no longer clusters Meta on Windows emulation; Ctrl shows expected commands.
 - [2025-08-10 17:35 UTC] Reverted per-OS layout copies and override structures. Introduced Key-level `os` config (single JSON) and apply per-OS label/code/unicode/modifier at init. Kept minimal logic and removed ad-hoc swaps.
 - [2025-08-10 17:50 UTC] Updated `README.md` to include a "Custom Keyboard Layouts" section, documenting the Key-level `os` configuration for end-users.
+- [2025-08-10 18:20 UTC] Added letter and digit code aliases in `VisualKeyboardManager` to restore heatmaps for literal keys.
 
 ## Decisions
 - [2025-08-10] Implemented `normalizeKeyDisplay` utility to provide platform-aware, text-first labels for keys and modifiers.


### PR DESCRIPTION
## Summary
- map letter and digit hotkeys to their corresponding `Key*`/`Digit*` codes to show heatmap weights
- document heatmap fix in task log

## Testing
- `npx @biomejs/biome format src/managers/visualKeyboardsManager/visualKeyboardsManager.svelte.ts tasks/25081003-baked-key-display-names.md` *(fails: 403 Forbidden - GET https://registry.npmjs.org/@biomejs%2fbiome)*
- `npx @biomejs/biome check src/managers/visualKeyboardsManager/visualKeyboardsManager.svelte.ts tasks/25081003-baked-key-display-names.md` *(fails: 403 Forbidden - GET https://registry.npmjs.org/@biomejs%2fbiome)*
- `npm run build` *(fails: Could not resolve "../components/KeyboardComponent.svelte" from "src/views/ShortcutsView.ts" )*

------
https://chatgpt.com/codex/tasks/task_e_6898a6fe3fac8323bd8b02c8f65df4da