### PR TITLE
fix(visual-keyboard): limit hover preview to Alt and highlight modifiers

### DIFF
--- a/src/Components/CommandsList.svelte
+++ b/src/Components/CommandsList.svelte
@@ -3,7 +3,7 @@
   import type KeyboardAnalyzerPlugin from '../main'
   import type { commandEntry, hotkeyEntry } from '../interfaces/Interfaces'
   import { Star as StarIcon, ChevronDown, FolderPlus as FolderPlusIcon, Search as SearchIcon } from 'lucide-svelte'
-  import AddToGroupPopover from './AddToGroupPopover.svelte'
+  import AddToGroupPopover from '../components/AddToGroupPopover.svelte'
   import type SettingsManager from '../managers/settingsManager'
   import type GroupManager from '../managers/groupManager'
   import type { VisualKeyboardManager } from '../managers/visualKeyboardsManager/visualKeyboardsManager.svelte'
@@ -88,6 +88,10 @@
   // Hover preview for hotkeys on the visual keyboard
   function handleHotkeyMouseEnter(hk: hotkeyEntry) {
     const mods = convertModifiers(hk.modifiers)
+    visualKeyboardManager.updateVisualState(
+      activeKeysStore.ActiveKey,
+      activeKeysStore.ActiveModifiers,
+    )
     visualKeyboardManager.previewHoverState(hk.key, mods)
   }
   function handleHotkeyMouseLeave() {

--- a/src/Components/KeyboardComponent.svelte
+++ b/src/Components/KeyboardComponent.svelte
@@ -15,7 +15,7 @@
 
   import type CommandsManager from '../managers/commandsManager'
 
-  import KeyboardLayoutComponent from './KeyboardLayoutComponent.svelte'
+  import KeyboardLayoutComponent from '../components/KeyboardLayoutComponent.svelte'
   import SearchMenu from './SearchMenu.svelte'
   import CommandsList from './CommandsList.svelte'
   import { GroupType } from '../managers/groupManager/groupManager.svelte'

--- a/src/Components/KeyboardKey.svelte
+++ b/src/Components/KeyboardKey.svelte
@@ -73,6 +73,43 @@
       activeKeysStore.activeModifiers,
     )
   }
+
+  let previewing = false
+  let storedKey = ''
+  let altReleaseListener: ((e: KeyboardEvent) => void) | null = null
+
+  function handleMouseEnter(event: MouseEvent) {
+    const isModifierKey = visualKeyboardManager.mapCodeToObsidianModifier(
+      key.code || key.label,
+    )
+    if (event.altKey && !isModifierKey) {
+      if (!previewing) {
+        storedKey = activeKeysStore.ActiveKey
+        altReleaseListener = (e: KeyboardEvent) => {
+          if (e.key === 'Alt') {
+            activeKeysStore.ActiveKey = storedKey
+            previewing = false
+            window.removeEventListener('keyup', altReleaseListener!)
+            altReleaseListener = null
+          }
+        }
+        window.addEventListener('keyup', altReleaseListener)
+      }
+      previewing = true
+      activeKeysStore.ActiveKey = key.code || key.label
+    }
+  }
+
+  function handleMouseLeave() {
+    if (previewing) {
+      activeKeysStore.ActiveKey = storedKey
+      previewing = false
+      if (altReleaseListener) {
+        window.removeEventListener('keyup', altReleaseListener)
+        altReleaseListener = null
+      }
+    }
+  }
 </script>
 
 {#if displayLabel === 'empty'}
@@ -97,6 +134,8 @@
     class:small-text={key.smallText}
     style={`grid-row: ${getRowSpan(height)}; grid-column: ${getColumnSpan(width)}; ${keyState.state === 'active' ? `background-color: var(--interactive-accent);` : (keyState.state === 'inactive' || keyState.state === 'possible') && keyState.weight ? `background-color: rgb(from var(--color-red) r g b / ${calculateOpacity(spreadWeights(keyState.weight))}%);` : ''}`}
     onclick={() => handleClick(key)}
+    onmouseenter={handleMouseEnter}
+    onmouseleave={handleMouseLeave}
   >
     {displayLabel}
     <!-- <span class="debug-weight font-300 text-[10px]">{keyState.weight}</span> --var(--interactive-accent); -->

--- a/src/Components/SearchMenu.svelte
+++ b/src/Components/SearchMenu.svelte
@@ -209,7 +209,6 @@
     if (keyboardListenerIsActive) {
       PressedKeysStore.handleKeyDown(e)
     }
-    PressedKeysStore.handlePhysicalKeyDown(e)
     // Re-apply search when hotkey listeners mutate active keys
     handleSearchInput()
   }
@@ -247,7 +246,7 @@
     selectedGroup
     handleSearchInput()
   })
-  import GroupSelector from './GroupSelector.svelte'
+  import GroupSelector from '../components/GroupSelector.svelte'
 </script>
 
 <GroupSelector bind:selectedGroup />

--- a/src/components/KeyboardLayoutComponent.svelte
+++ b/src/components/KeyboardLayoutComponent.svelte
@@ -8,7 +8,7 @@
     commandEntry,
     KeyboardSection,
   } from '../interfaces/Interfaces'
-  import KeyboardKey from './KeyboardKey.svelte'
+  import KeyboardKey from '../Components/KeyboardKey.svelte'
   import { Coffee as CoffeeIcon, Pin as PinIcon, Settings as SettingsIcon } from 'lucide-svelte'
   import type { VisualKeyboardManager } from '../managers/visualKeyboardsManager/visualKeyboardsManager.svelte'
   import type CommandsManager from '../managers/commandsManager'

--- a/src/managers/visualKeyboardsManager/visualKeyboardsManager.svelte.ts
+++ b/src/managers/visualKeyboardsManager/visualKeyboardsManager.svelte.ts
@@ -36,7 +36,14 @@ export class VisualKeyboardManager {
   private getProcessedLayout(src: KeyboardLayout): KeyboardLayout {
     const emu = getEmulatedOS()
     const os: 'macos' | 'windows' | 'linux' =
-      emu === 'macos' ? 'macos' : emu === 'linux' ? 'linux' : Platform.isMacOS ? 'macos' : 'windows'
+      emu === 'none'
+        ? Platform.isMacOS
+          ? 'macos'
+          : // @ts-expect-error -- `isLinux` exists at runtime
+            Platform.isLinux
+          ? 'linux'
+          : 'windows'
+        : emu
 
     const processedSections = src.sections.map((section) => ({
       ...section,
@@ -227,6 +234,11 @@ export class VisualKeyboardManager {
       Object.entries(symbolToCode).map(([sym, code]) => [code, sym])
     )
     if (key in codeToSymbol) out.add(codeToSymbol[key])
+    // Letters and digits ↔ code aliases (e.g., 'a' ↔ 'keya', '1' ↔ 'digit1')
+    if (/^[a-z]$/.test(key)) out.add(`key${key}`)
+    if (/^key[a-z]$/.test(key)) out.add(key.slice(3))
+    if (/^[0-9]$/.test(key)) out.add(`digit${key}`)
+    if (/^digit[0-9]$/.test(key)) out.add(key.slice(5))
     return Array.from(out)
   }
 
@@ -319,8 +331,13 @@ export class VisualKeyboardManager {
     }
 
     const lowerKey = (previewKey || '').toLowerCase()
-    if (this.keyStates[lowerKey] && this.keyStates[lowerKey].state !== 'active') {
-      this.keyStates[lowerKey].state = 'hover'
+    const aliases = this.resolveKeyAliases(lowerKey)
+    for (const alias of aliases) {
+      const state = this.keyStates[alias]
+      if (state) {
+        state.state = 'hover'
+        break
+      }
     }
 
     // Normalize incoming modifiers into abstract names used by normalizeModifier
@@ -333,9 +350,7 @@ export class VisualKeyboardManager {
       const code = this.keyStates[key].code
       const abstract = this.normalizeModifier(code)
       if (abstract && abstractMods.has(abstract as unknown as Modifier)) {
-        if (this.keyStates[key].state !== 'active') {
-          this.keyStates[key].state = 'hover'
-        }
+        this.keyStates[key].state = 'hover'
       }
     }
   }

--- a/src/stores/activeKeysStore.svelte.ts
+++ b/src/stores/activeKeysStore.svelte.ts
@@ -3,8 +3,6 @@ import { Platform } from 'obsidian'
 import { getEmulatedOS } from '../utils/runtimeConfig'
 import {
   convertModifier,
-  getDisplayModifier,
-  modifierMap,
   type ModifierKey,
   sortModifiers,
 } from '../utils/modifierUtils'
@@ -142,16 +140,6 @@ export class ActiveKeysStore {
       })(),
     }
     return keyMap[keyIdentifier] || keyIdentifier
-  }
-
-  public handlePhysicalKeyDown(e: KeyboardEvent) {
-    // const keyLabel = this.normalizeKeyIdentifier(e.key)
-    // if (this.recognizedModifiers.has(keyLabel)) {
-    //   const modifierKey = convertModifier(keyLabel as ModifierKey)
-    //   if (modifierKey) {
-    //     this.toggleModifier(modifierKey)
-    //   }
-    // }
   }
 
   public getDisplayKey() {

--- a/src/views/ShortcutsView.ts
+++ b/src/views/ShortcutsView.ts
@@ -2,7 +2,7 @@ import { ItemView, type WorkspaceLeaf } from 'obsidian'
 import { mount, unmount } from 'svelte'
 
 import type KeyboardAnalyzerPlugin from '../main'
-import KeyboardComponent from '../components/KeyboardComponent.svelte'
+import KeyboardComponent from '../Components/KeyboardComponent.svelte'
 import { ActiveKeysStore } from '../stores/activeKeysStore.svelte'
 import { VIEW_TYPE_SHORTCUTS_ANALYZER } from '../Constants'
 import { VisualKeyboardManager } from '../managers'

--- a/tasks/25081001-visual-keyboard-keys-and-hover-highlights.md
+++ b/tasks/25081001-visual-keyboard-keys-and-hover-highlights.md
@@ -2,7 +2,7 @@
 title: Fix visual keyboard keys mapping and hover highlight contrast
 status: in_progress
 owner: "@agent"
-updated: 2025-08-09 23:30 UTC
+updated: 2025-08-10 18:00 UTC
 related:
   - [[25080914-hotkey-groups]]
 ---
@@ -18,6 +18,12 @@ Definition of done:
 
 ## Decisions
 - [2025-08-09] Track this as a focused visual/UX fix before next build.
+- [2025-08-10] Restored command-hover highlighting for literal keys.
+- [2025-08-10] Added modifier-hover hotkey preview.
+- [2025-08-10] Simplified modifier-hover preview to rely on held modifiers during hover.
+- [2025-08-10] Hover previews add only the hovered key; physically held modifiers are ignored in search.
+- [2025-08-10] Hover preview is limited to the Alt modifier and clears on Alt release.
+- [2025-08-10] Command list hover now highlights modifiers even if they are active.
 
 ## Next Steps
 - [ ] Correct Windows bottom-row mapping for `Win` and `Alt` in keyboard layout/config.
@@ -26,6 +32,8 @@ Definition of done:
 - Visual keyboard's - Other keys:
   - the backspace key `⌫` produces the `⌫` symbol in search, but I think it should be Backspace. Please create new task for correctly displaying (some sort of baked) keys and modifiers in search menu and in the commands list. Please also add a dev log feature toggle to turn this on/off for ease of debugging.
   - Clicking on `Arrows` visual keys producing correct baked `arrows` in search menu, but in command list they displayed as `Arrow{direction}`
+- [x] Restore highlighting for letter and digit keys when hovering command hotkeys.
+- [x] Preview hotkeys by holding modifiers and hovering visual keys.
 - [ ] Sanity-check macOS/Linux layouts unaffected by change.
 - [ ] Verify with keyboard listener on/off and with heatmap scope toggles.
 - [ ] Update screenshots/notes after validation in test-vault.

--- a/tasks/25081003-baked-key-display-names.md
+++ b/tasks/25081003-baked-key-display-names.md
@@ -2,7 +2,7 @@
 title: Baked key display names in search and commands list
 status: in_progress
 owner: "@agent"
-updated: 2025-08-10 14:45 UTC
+updated: 2025-08-10 19:10 UTC
 related:
   - [[25081001-visual-keyboard-keys-and-hover-highlights]]
   - [[25080913-SPRINT-list-of-bugs-and-new-feature-requests]]
@@ -48,6 +48,8 @@ Definition of done:
 - [2025-08-10 17:15 UTC] Introduced platformized modifiers: transform command hotkeys and active modifiers to OS-appropriate forms (Meta→Ctrl on Windows) for rendering and matching. Commands list no longer clusters Meta on Windows emulation; Ctrl shows expected commands.
 - [2025-08-10 17:35 UTC] Reverted per-OS layout copies and override structures. Introduced Key-level `os` config (single JSON) and apply per-OS label/code/unicode/modifier at init. Kept minimal logic and removed ad-hoc swaps.
 - [2025-08-10 17:50 UTC] Updated `README.md` to include a "Custom Keyboard Layouts" section, documenting the Key-level `os` configuration for end-users.
+- [2025-08-10 18:20 UTC] Added letter and digit code aliases in `VisualKeyboardManager` to restore heatmaps for literal keys.
+- [2025-08-10 19:10 UTC] Corrected OS emulation layout mapping so bottom row modifiers reflect Windows vs macOS; fixed case-sensitive import for `KeyboardComponent`.
 
 ## Decisions
 - [2025-08-10] Implemented `normalizeKeyDisplay` utility to provide platform-aware, text-first labels for keys and modifiers.


### PR DESCRIPTION
## Summary
- preview hotkeys only when Alt is held, restoring the previous key when Alt is released
- highlight all keys for command list hovers even if some modifiers are already active
- record Alt-only hover behavior in the visual keyboard task file

## Testing
- `npx @biomejs/biome format src/Components/KeyboardKey.svelte src/Components/CommandsList.svelte src/managers/visualKeyboardsManager/visualKeyboardsManager.svelte.ts tasks/25081001-visual-keyboard-keys-and-hover-highlights.md` *(fails: 403 Forbidden - GET https://registry.npmjs.org/@biomejs%2fbiome)*
- `npx @biomejs/biome check src/Components/KeyboardKey.svelte src/Components/CommandsList.svelte src/managers/visualKeyboardsManager/visualKeyboardsManager.svelte.ts tasks/25081001-visual-keyboard-keys-and-hover-highlights.md` *(fails: 403 Forbidden - GET https://registry.npmjs.org/@biomejs%2fbiome)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6898a6fe3fac8323bd8b02c8f65df4da