### PR TITLE
chore: fix TypeScript and Svelte checks

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -15,6 +15,7 @@
 
 ## Coding Style & Naming Conventions
 - Language: TypeScript (strict) + Svelte 5.
+- Obsidian API typings: import from the official `obsidian` package; internal members are declared via `src/types/obsidian-augmentations.d.ts`.
 - Components: PascalCase (e.g., `KeyboardLayoutComponent.svelte`). Utilities/managers: camelCase filenames (e.g., `hotkeyManager`).
 - Indentation: 2 spaces; prefer explicit types and `const` where possible.
 - Formatting/Linting: Biome config present (`biome.json`). Example: `npx @biomejs/biome check .` and `npx @biomejs/biome format .`.

--- a/src/components/AddToGroupPopover.svelte
+++ b/src/components/AddToGroupPopover.svelte
@@ -58,7 +58,7 @@
 <div
   class="kb-popover {placeAbove ? 'is-above' : 'is-below'}"
   use:clickOutside
-  ononclick_outside={onClose}
+  onclick_outside={onClose}
   role="dialog"
   aria-label="Add to group"
   bind:this={rootEl}

--- a/src/components/CommandsList.svelte
+++ b/src/components/CommandsList.svelte
@@ -3,7 +3,7 @@
   import type KeyboardAnalyzerPlugin from '../main'
   import type { commandEntry, hotkeyEntry } from '../interfaces/Interfaces'
   import { Star as StarIcon, ChevronDown, FolderPlus as FolderPlusIcon, Search as SearchIcon } from 'lucide-svelte'
-  import AddToGroupPopover from '../components/AddToGroupPopover.svelte'
+  import AddToGroupPopover from './AddToGroupPopover.svelte'
   import type SettingsManager from '../managers/settingsManager'
   import type GroupManager from '../managers/groupManager'
   import type { VisualKeyboardManager } from '../managers/visualKeyboardsManager/visualKeyboardsManager.svelte'

--- a/src/components/GroupManagerModal.svelte
+++ b/src/components/GroupManagerModal.svelte
@@ -20,8 +20,8 @@
     plugin = getContext('keyboard-analyzer-plugin')
   }
 
-  const groupManager = plugin.groupManager
-  const commandsManager = plugin.commandsManager
+  const groupManager = plugin!.groupManager
+  const commandsManager = plugin!.commandsManager
 
   let groups = $derived.by(() => groupManager.getGroups())
 

--- a/src/components/KeyboardComponent.svelte
+++ b/src/components/KeyboardComponent.svelte
@@ -15,7 +15,7 @@
 
   import type CommandsManager from '../managers/commandsManager'
 
-  import KeyboardLayoutComponent from '../components/KeyboardLayoutComponent.svelte'
+  import KeyboardLayoutComponent from './KeyboardLayoutComponent.svelte'
   import SearchMenu from './SearchMenu.svelte'
   import CommandsList from './CommandsList.svelte'
   import { GroupType } from '../managers/groupManager/groupManager.svelte'

--- a/src/components/KeyboardKey.svelte
+++ b/src/components/KeyboardKey.svelte
@@ -1,4 +1,4 @@
-<!-- src/Components/KeyboardKey.svelte -->
+<!-- src/components/KeyboardKey.svelte -->
 <script lang="ts">
   import type { Key } from '../interfaces/Interfaces'
   import { getContext } from 'svelte'
@@ -16,7 +16,8 @@
       unicode: '',
       width: 1,
       height: 1,
-    },
+      type: 'empty',
+    } as Key,
     maxWeightSteps = 5,
   }: Props = $props()
 
@@ -59,7 +60,7 @@
   }
 
   function handleClick(key: Key) {
-    const keyIdentifier = key.code || key.label
+    const keyIdentifier = key.code || key.label || ''
     ;(async () => {
       const { default: logger } = await import('../utils/logger')
       logger.debug('Clicked key:', keyIdentifier)
@@ -91,7 +92,7 @@
       window.addEventListener('keyup', altReleaseListener)
     }
     previewing = true
-    activeKeysStore.ActiveKey = key.code || key.label
+    activeKeysStore.ActiveKey = key.code || key.label || ''
   }
 
   function stopPreview() {
@@ -106,7 +107,7 @@
   function handleMouseEnter(event: MouseEvent) {
     hovered = true
     const isModifierKey = visualKeyboardManager.mapCodeToObsidianModifier(
-      key.code || key.label,
+      key.code || key.label || '',
     )
 
     if (!isModifierKey) {

--- a/src/components/KeyboardLayoutComponent.svelte
+++ b/src/components/KeyboardLayoutComponent.svelte
@@ -1,4 +1,4 @@
-<!-- src/Components/KeyboardLayoutComponent.svelte -->
+<!-- src/components/KeyboardLayoutComponent.svelte -->
 <script lang="ts">
   import { setContext, getContext } from 'svelte'
   import type { ActiveKeysStore } from '../stores/activeKeysStore.svelte'
@@ -8,7 +8,7 @@
     commandEntry,
     KeyboardSection,
   } from '../interfaces/Interfaces'
-  import KeyboardKey from '../Components/KeyboardKey.svelte'
+  import KeyboardKey from './KeyboardKey.svelte'
   import { Coffee as CoffeeIcon, Pin as PinIcon, Settings as SettingsIcon } from 'lucide-svelte'
   import type { VisualKeyboardManager } from '../managers/visualKeyboardsManager/visualKeyboardsManager.svelte'
   import type CommandsManager from '../managers/commandsManager'

--- a/src/components/SearchMenu.svelte
+++ b/src/components/SearchMenu.svelte
@@ -22,7 +22,6 @@
   import type { FilterSettings } from '../managers/settingsManager'
   import { convertModifiers, unconvertModifier } from '../utils/modifierUtils'
   import type { Modifier } from 'obsidian'
-  // @ts-ignore: No type declaration for clickOutside
   import { clickOutside } from '../utils/clickOutside'
   import logger from '../utils/logger'
   import { getBakedModifierLabel, getBakedKeyLabel } from '../utils/normalizeKeyDisplay'
@@ -246,7 +245,7 @@
     selectedGroup
     handleSearchInput()
   })
-  import GroupSelector from '../components/GroupSelector.svelte'
+  import GroupSelector from './GroupSelector.svelte'
 </script>
 
 <GroupSelector bind:selectedGroup />
@@ -318,7 +317,7 @@
   <div
     class="menu-anchor"
     use:clickOutside
-    ononclick_outside={() => (filterIsOpen = false)}
+    onclick_outside={() => (filterIsOpen = false)}
   >
     <button
       id="hotkey-filter-button"
@@ -475,7 +474,7 @@
   <div
     class="menu-anchor"
     use:clickOutside
-    ononclick_outside={() => (viewDropdownOpen = false)}
+    onclick_outside={() => (viewDropdownOpen = false)}
   >
     <button
       id="hotkey-view-button"

--- a/src/interfaces/Interfaces.ts
+++ b/src/interfaces/Interfaces.ts
@@ -1,16 +1,5 @@
 // src/interfaces/Interfaces.ts
-import type {
-  Command,
-  Hotkey,
-  Modifier,
-  App,
-  SuggestModal,
-  HotkeyManager as ObsidianHotkeyManager,
-  InternalPlugins,
-  KeymapInfo,
-  InternalPlugin,
-  InternalPluginInstance,
-} from 'obsidian-typings'
+import type { Command, Hotkey, Modifier, App, KeymapInfo } from 'obsidian'
 
 export interface commandEntry {
   id: string
@@ -26,10 +15,9 @@ export interface commandEntry {
 export type commandsArray = commandEntry[]
 
 // Plugin Data
-export interface hotkeyEntry extends Omit<Hotkey, 'modifiers'> {
-  modifiers: Modifier[]
-  backedModifiers?: string
+export interface hotkeyEntry extends Hotkey {
   isCustom: boolean
+  backedModifiers?: string
 }
 
 export interface hotkeyDict {
@@ -79,7 +67,7 @@ export interface KeyboardKeyState {
   smallText?: boolean
 }
 
-export interface UnsafeHotkeyManager extends ObsidianHotkeyManager {
+export interface UnsafeHotkeyManager {
   getHotkeys(id: string): KeymapInfo[]
   getDefaultHotkeys(id: string): KeymapInfo[]
   customKeys: Record<string, KeymapInfo[]>
@@ -102,26 +90,15 @@ export interface UnsafeCommands {
   executeCommandById(id: string): boolean
 }
 
-export interface UnsafeAppInterface extends App {
-  commands: UnsafeCommands
-  HotKeyManager: UnsafeHotkeyManager
-  internalPlugins: InternalPlugins & {
-    getPluginById(id: string): { instance: { options: { pinned: [] } } }
-  } & { getEnabledPlugins(): UnsafeInternalPlugin[] }
-}
-
-export interface UnsafeInternalPlugin extends InternalPlugin {
-  instance: InternalPluginInstance & {
-    id: string
-    name: string
-    commands?: Record<string, Command>
-  }
-}
-
-export interface UnsafeInternalPluginInstance extends InternalPluginInstance {
+export interface UnsafeInternalPluginInstance {
   id: string
   name: string
   commands?: Record<string, Command>
+}
+
+export interface UnsafeInternalPlugin {
+  manifest?: { id?: string; name?: string }
+  instance: UnsafeInternalPluginInstance
 }
 
 // Helper type to convert KeymapInfo to Hotkey

--- a/src/managers/commandsManager/commandsManager.svelte.ts
+++ b/src/managers/commandsManager/commandsManager.svelte.ts
@@ -1,17 +1,9 @@
-import type {
-  App,
-  InternalPlugin,
-  InternalPluginName,
-  Command,
-  Plugin,
-} from 'obsidian-typings'
+import type { App, Command, Plugin } from 'obsidian'
 import type {
   hotkeyEntry,
   UnsafeInternalPlugin,
-  UnsafeInternalPluginInstance,
   commandEntry,
 } from '../../interfaces/Interfaces'
-import type { UnsafeAppInterface } from '../../interfaces/Interfaces'
 import HotkeyManager from '../hotkeyManager/hotkeyManager.svelte'
 import SettingsManager, { GroupType, type CGroup } from '../settingsManager'
 import {
@@ -91,8 +83,7 @@ export default class CommandsManager {
    * @returns Command[]
    */
   private getCommands(): Command[] {
-    const unsafeApp = this.app as UnsafeAppInterface
-    return Object.values(unsafeApp.commands.commands)
+    return Object.values(this.app.commands.commands)
   }
 
   /**
@@ -128,16 +119,12 @@ export default class CommandsManager {
    * @returns string - The name of the plugin
    */
   public getPluginName(pluginId: string): string {
-    const plugin = (this.app as UnsafeAppInterface).plugins.plugins[pluginId]
+    const plugin = this.app.plugins.plugins[pluginId]
     if (plugin) return plugin.manifest.name
 
-    const internalPlugins = (
-      this.app as UnsafeAppInterface
-    ).internalPlugins.getEnabledPlugins()
-
+    const internalPlugins = this.app.internalPlugins.getEnabledPlugins()
     const internalPlugin = internalPlugins.find(
-      (plugin) =>
-        (plugin.instance as UnsafeInternalPluginInstance).id === pluginId
+      (plugin) => plugin.instance.id === pluginId
     ) as UnsafeInternalPlugin | undefined
 
     if (internalPlugin?.instance) {
@@ -148,41 +135,10 @@ export default class CommandsManager {
   }
 
   /**
-  * Returns a boolean value indicating if a command is an internal module
-  *
-  * @param commandId - The ID of the command to check
-  * @returns boolean
-  * @types of InternalPluginName from obsidian-typings
-  type InternalPluginName =
-		| "audio-recorder"
-		| "backlink"
-		| "bookmarks"
-		| "canvas"
-		| "command-palette"
-		| "daily-notes"
-		| "editor-status"
-		| "file-explorer"
-		| "file-recovery"
-		| "global-search"
-		| "graph"
-		| "markdown-importer"
-		| "note-composer"
-		| "outgoing-link"
-		| "outline"
-		| "page-preview"
-		| "properties"
-		| "publish"
-		| "random-note"
-		| "slash-command"
-		| "slides"
-		| "starred"
-		| "switcher"
-		| "sync"
-		| "tag-pane"
-		| "templates"
-		| "word-count"
-		| "workspaces"
-		| "zk-prefixer";
+   * Returns a boolean value indicating if a command is an internal module
+   *
+   * @param commandId - The ID of the command to check
+   * @returns boolean
    */
   public isInternalModule(commandId: string): boolean {
     const pluginId = (commandId || '').split(':')[0] || ''
@@ -218,7 +174,7 @@ export default class CommandsManager {
       'word-count',
       'workspaces',
       'zk-prefixer',
-    ] as InternalPluginName[]
+    ]
 
     // Additional core namespaces used by Obsidian for built-in commands
     const coreNamespaces = [
@@ -231,16 +187,15 @@ export default class CommandsManager {
       'workspace',
     ]
 
-    if (internalModules.includes(pluginId as InternalPluginName)) return true
+    if (internalModules.includes(pluginId)) return true
     if (coreNamespaces.includes(pluginId)) return true
 
     // Heuristic fallback: if not a community plugin and not an internal plugin id, treat as internal
-    const unsafe = this.app as UnsafeAppInterface
-    const isCommunity = Boolean(unsafe.plugins.plugins[pluginId])
+    const isCommunity = Boolean(this.app.plugins.plugins[pluginId])
     if (isCommunity) return false
-    const enabledInternal = unsafe.internalPlugins.getEnabledPlugins() as InternalPlugin[]
+    const enabledInternal = this.app.internalPlugins.getEnabledPlugins()
     const isInternal = enabledInternal.some(
-      (p) => (p.instance as UnsafeInternalPluginInstance).id === pluginId
+      (p) => p.instance.id === pluginId
     )
     return isInternal || !isCommunity
   }
@@ -442,9 +397,7 @@ export default class CommandsManager {
    * @returns {Plugin[]}
    */
   public getInstalledPluginIDs(): string[] {
-    const internalPlugins = (
-      this.app as UnsafeAppInterface
-    ).internalPlugins.getEnabledPlugins() as InternalPlugin[]
+    const internalPlugins = this.app.internalPlugins.getEnabledPlugins()
 
     const internalPluginIDs = internalPlugins.map(
       (plugin) => plugin.manifest?.id || ''

--- a/src/managers/hotkeyManager/hotkeyManager.svelte.ts
+++ b/src/managers/hotkeyManager/hotkeyManager.svelte.ts
@@ -1,10 +1,8 @@
 import type { App, KeymapInfo, Hotkey, Modifier, Command } from 'obsidian'
 import type {
-  UnsafeAppInterface,
   hotkeyEntry,
   commandEntry,
   UnsafeInternalPlugin,
-  UnsafeInternalPluginInstance,
 } from '../../interfaces/Interfaces'
 import {
   convertModifiers,
@@ -41,8 +39,7 @@ export default class HotkeyManager {
   }
 
   private getCommands(): Command[] {
-    const unsafeApp = this.app as UnsafeAppInterface
-    const commands = unsafeApp.commands.commands
+    const commands = this.app.commands.commands
     return Object.values(commands)
   }
 
@@ -109,27 +106,23 @@ export default class HotkeyManager {
     if (internalModules.includes(pluginId)) return true
     if (coreNamespaces.includes(pluginId)) return true
     // Heuristic fallback: not a community plugin => internal
-    const unsafe = this.app as UnsafeAppInterface
-    const isCommunity = Boolean(unsafe.plugins.plugins[pluginId])
+    const isCommunity = Boolean(this.app.plugins.plugins[pluginId])
     if (isCommunity) return false
-    const enabledInternal = unsafe.internalPlugins.getEnabledPlugins() as UnsafeInternalPlugin[]
+    const enabledInternal = this.app.internalPlugins.getEnabledPlugins()
     const isInternal = enabledInternal.some(
-      (p) => (p.instance as UnsafeInternalPluginInstance).id === pluginId
+      (p) => p.instance.id === pluginId
     )
     return isInternal || !isCommunity
   }
 
   private getPluginName(pluginId: string): string {
-    const plugin = (this.app as UnsafeAppInterface).plugins.plugins[pluginId]
+    const plugin = this.app.plugins.plugins[pluginId]
     if (plugin) return plugin.manifest.name
 
-    const internalPlugins = (
-      this.app as UnsafeAppInterface
-    ).internalPlugins.getEnabledPlugins()
+    const internalPlugins = this.app.internalPlugins.getEnabledPlugins()
 
     const internalPlugin = internalPlugins.find(
-      (plugin) =>
-        (plugin.instance as UnsafeInternalPluginInstance).id === pluginId
+      (plugin) => plugin.instance.id === pluginId
     ) as UnsafeInternalPlugin | undefined
 
     if (internalPlugin?.instance) {
@@ -144,9 +137,8 @@ export default class HotkeyManager {
     default: hotkeyEntry[]
     custom: hotkeyEntry[]
   } {
-    const unsafeApp = this.app as UnsafeAppInterface
-    const defaultHotkeys = unsafeApp.hotkeyManager.getDefaultHotkeys(id) || []
-    const customHotkeys = unsafeApp.hotkeyManager.customKeys[id] || []
+    const defaultHotkeys = this.app.hotkeyManager.getDefaultHotkeys(id) || []
+    const customHotkeys = this.app.hotkeyManager.customKeys[id] || []
 
     const processHotkeys = (
       hotkeys: KeymapInfo[],

--- a/src/managers/visualKeyboardsManager/visualKeyboardsManager.svelte.ts
+++ b/src/managers/visualKeyboardsManager/visualKeyboardsManager.svelte.ts
@@ -39,8 +39,7 @@ export class VisualKeyboardManager {
       emu === 'none'
         ? Platform.isMacOS
           ? 'macos'
-          : // @ts-expect-error -- `isLinux` exists at runtime
-            Platform.isLinux
+          : (Platform as { isLinux?: boolean }).isLinux
           ? 'linux'
           : 'windows'
         : emu

--- a/src/stores/activeKeysStore.svelte.ts
+++ b/src/stores/activeKeysStore.svelte.ts
@@ -102,6 +102,14 @@ export class ActiveKeysStore {
     this.handleKeyClick(keyCode)
   }
 
+  public handlePhysicalKeyDown(e: KeyboardEvent) {
+    this.handleKeyDown(e)
+  }
+
+  public handlePhysicalKeyUp(_e: KeyboardEvent) {
+    this.reset()
+  }
+
   private isModifier(key: string): key is ModifierKey {
     return this.recognizedModifiers.has(key as ModifierKey)
   }

--- a/src/types/obsidian-augmentations.d.ts
+++ b/src/types/obsidian-augmentations.d.ts
@@ -1,0 +1,15 @@
+import 'obsidian'
+import type { UnsafeCommands, UnsafeHotkeyManager, UnsafeInternalPlugin } from '../interfaces/Interfaces'
+
+declare module 'obsidian' {
+  interface App {
+    commands: UnsafeCommands
+    hotkeyManager: UnsafeHotkeyManager
+    plugins: {
+      plugins: Record<string, { manifest: { name: string } }>
+    }
+    internalPlugins: {
+      getEnabledPlugins(): UnsafeInternalPlugin[]
+    }
+  }
+}

--- a/src/types/shims.d.ts
+++ b/src/types/shims.d.ts
@@ -1,0 +1,5 @@
+declare namespace svelteHTML {
+  interface HTMLAttributes<T> {
+    onclick_outside?: (event: CustomEvent<any>) => void
+  }
+}

--- a/src/utils/clickOutside.d.ts
+++ b/src/utils/clickOutside.d.ts
@@ -1,0 +1,1 @@
+export function clickOutside(node: HTMLElement): { destroy(): void }

--- a/src/views/ShortcutsView.ts
+++ b/src/views/ShortcutsView.ts
@@ -2,7 +2,7 @@ import { ItemView, type WorkspaceLeaf } from 'obsidian'
 import { mount, unmount } from 'svelte'
 
 import type KeyboardAnalyzerPlugin from '../main'
-import KeyboardComponent from '../Components/KeyboardComponent.svelte'
+import KeyboardComponent from '../components/KeyboardComponent.svelte'
 import { ActiveKeysStore } from '../stores/activeKeysStore.svelte'
 import { VIEW_TYPE_SHORTCUTS_ANALYZER } from '../Constants'
 import { VisualKeyboardManager } from '../managers'

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -15,7 +15,7 @@
     "strict": true,
     "target": "es6",
     "useDefineForClassFields": true,
-    "types": ["obsidian-typings", "svelte", "node"]
+    "types": ["obsidian", "svelte", "node"]
   },
   "include": ["src/**/*.d.ts", "src/**/*.ts", "src/**/*.js", "src/**/*.svelte"]
 }


### PR DESCRIPTION
## Summary
- standardize on official `obsidian` types with module augmentations
- add typed shim for `clickOutside` action and normalize component imports
- expose physical key handlers in `ActiveKeysStore`

## Testing
- `npx tsc -p tsconfig.json --noEmit`
- `npx svelte-check --tsconfig ./tsconfig.json`
- `npx @biomejs/biome check .` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_6898c564a5dc8323bc0a7382d8dda33d