### PR TITLE
Persist keyboard collapse state

### DIFF
--- a/src/components/KeyboardLayoutComponent.svelte
+++ b/src/components/KeyboardLayoutComponent.svelte
@@ -64,7 +64,9 @@
   )
 
   // Local UI state for toolbar controls
-  let panelCollapsed = $state(false)
+  let panelCollapsed = $state(
+    Boolean(settingsManager.getSetting('keyboardCollapsed')),
+  )
   let isPinned = $state(Boolean(settingsManager.getSetting('pinKeyboardPanel')))
   let heatmapScope: 'filtered' | 'all' = $state('filtered')
   let devMenuOpen = $state(false)
@@ -89,7 +91,10 @@
         class="panel-toggle"
         aria-label={panelCollapsed ? 'Expand keyboard' : 'Collapse keyboard'}
         aria-expanded={!panelCollapsed}
-        onclick={() => (panelCollapsed = !panelCollapsed)}
+        onclick={() => {
+          panelCollapsed = !panelCollapsed
+          settingsManager.updateSettings({ keyboardCollapsed: panelCollapsed })
+        }}
         title={panelCollapsed ? 'Show keyboard' : 'Hide keyboard'}
       >
         <span class={`chevron ${panelCollapsed ? 'is-collapsed' : ''}`}>⌄</span>

--- a/src/managers/settingsManager/settingsManager.d.ts
+++ b/src/managers/settingsManager/settingsManager.d.ts
@@ -9,6 +9,7 @@ export interface PluginSettings {
   commandGroups: CGroup[]
   lastOpenedGroupId?: string
   pinKeyboardPanel?: boolean
+  keyboardCollapsed?: boolean
   // Developer options (non-breaking defaults)
   enableDeveloperOptions?: boolean
   devLoggingEnabled?: boolean

--- a/src/managers/settingsManager/settingsManager.svelte.ts
+++ b/src/managers/settingsManager/settingsManager.svelte.ts
@@ -37,6 +37,7 @@ const DEFAULT_PLUGIN_SETTINGS: PluginSettings = {
   commandGroups: [],
   lastOpenedGroupId: 'all',
   pinKeyboardPanel: false,
+  keyboardCollapsed: false,
   enableDeveloperOptions: false,
   devLoggingEnabled: false,
   emulatedOS: 'none',

--- a/tasks/25080913-keyboard-panel-collapse-toggle.md
+++ b/tasks/25080913-keyboard-panel-collapse-toggle.md
@@ -2,7 +2,7 @@
 title: Collapse/expand Visual Keyboard panel
 status: in_progress
 owner: "@agent"
-updated: 2025-08-09 21:10 UTC
+updated: 2025-08-11 14:30 UTC
 related:
   - [[250809-list-of-bugs-and-new-feature-requests]]
 ---
@@ -22,10 +22,10 @@ Allow users to hide/show the visual keyboard to save space in narrow panes while
 - No horizontal overflow introduced in collapsed or expanded states.
 
 ## Next Steps
-- [ ] Add `keyboardCollapsed` state to store with persistence (owner)
+- [x] Add `keyboardCollapsed` state to store with persistence (owner)
 - [x] Render a toggle control in the keyboard header area (owner)
 - [x] Apply CSS to collapse panel cleanly; test narrow panes (owner)
-- [ ] SKIPPED: Verify accessibility (focus order, aria) and attach screenshots (owner) 
+- [ ] SKIPPED: Verify accessibility (focus order, aria) and attach screenshots (owner)
  - [x] Add Pin toggle, persistence, and sticky behavior (owner)
  - [ ] Optional: Add shadow and top offset for pinned state (owner)
 
@@ -39,3 +39,4 @@ Allow users to hide/show the visual keyboard to save space in narrow panes while
  - [2025-08-09 20:56 UTC] Investigated inconsistency: sticky released after ~panel height due to wrapper/overflow constraints; tested wrapper-level sticky and overflow visibility.
  - [2025-08-09 21:02 UTC] Final approach: panel is block-level and sticky; `#keyboard-component` uses `height:auto; min-height:100%`; wrapper `#keyboard-preview-view` allows overflow; added wrapper sticky fallback when panel pinned to ensure consistent pin across full scroll.
  - [2025-08-09 21:08 UTC] Verified: Pin now keeps the keyboard visible while scrolling long lists; will add minor polish (shadow/offset) if desired.
+- [2025-08-11 14:30 UTC] Persisted collapsed state via `keyboardCollapsed` setting; panel remembers state across reloads.


### PR DESCRIPTION
## Summary
- preserve keyboard panel's collapsed state between sessions via new `keyboardCollapsed` setting
- document progress for collapse toggle task

## Testing
- `npx --yes @biomejs/biome format src/managers/settingsManager/settingsManager.d.ts src/managers/settingsManager/settingsManager.svelte.ts src/components/KeyboardLayoutComponent.svelte tasks/25080913-keyboard-panel-collapse-toggle.md` *(fails: configuration schema mismatch)*
- `npx --yes @biomejs/biome check src/managers/settingsManager/settingsManager.d.ts src/managers/settingsManager/settingsManager.svelte.ts src/components/KeyboardLayoutComponent.svelte tasks/25080913-keyboard-panel-collapse-toggle.md` *(fails: configuration schema mismatch)*
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689a2b988114832395e9410ce37f5280