### PR TITLE
feat: persist heatmap scope with view dropdown toggle

### DIFF
--- a/src/components/KeyboardComponent.svelte
+++ b/src/components/KeyboardComponent.svelte
@@ -1,259 +1,284 @@
 <!-- src/components/KeyboardComponent.svelte -->
 
 <script lang="ts">
-  import { setContext, onMount } from 'svelte'
-  import type { Modifier } from 'obsidian'
-  import type KeyboardAnalyzerPlugin from '../main'
-  import type ShortcutsView from '../views/ShortcutsView'
-  import { ActiveKeysStore } from '../stores/activeKeysStore.svelte.ts'
-  import type {
-    commandEntry,
-    hotkeyEntry,
-  } from '../interfaces/Interfaces'
-  import { VisualKeyboardManager } from '../managers/visualKeyboardsManager/visualKeyboardsManager.svelte.ts'
-  import { convertModifiers } from '../utils/modifierUtils'
-  import logger from '../utils/logger'
+import type { Modifier } from "obsidian";
+import { onMount, setContext } from "svelte";
+import type { commandEntry, hotkeyEntry } from "../interfaces/Interfaces";
+import type KeyboardAnalyzerPlugin from "../main";
+import type CommandsManager from "../managers/commandsManager";
+import { GroupType } from "../managers/groupManager/groupManager.svelte.ts";
+import type SettingsManager from "../managers/settingsManager";
+import { VisualKeyboardManager } from "../managers/visualKeyboardsManager/visualKeyboardsManager.svelte.ts";
+import { ActiveKeysStore } from "../stores/activeKeysStore.svelte.ts";
+import logger from "../utils/logger";
+import { convertModifiers } from "../utils/modifierUtils";
+import type ShortcutsView from "../views/ShortcutsView";
+import CommandsList from "./CommandsList.svelte";
+import KeyboardLayoutComponent from "./KeyboardLayoutComponent.svelte";
+import SearchMenu from "./SearchMenu.svelte";
 
-  import type CommandsManager from '../managers/commandsManager'
+function isModF(e: KeyboardEvent) {
+	const isMod = e.metaKey || e.ctrlKey;
+	return isMod && !e.altKey && !e.shiftKey && e.key.toLowerCase() === "f";
+}
 
-  import KeyboardLayoutComponent from './KeyboardLayoutComponent.svelte'
-  import SearchMenu from './SearchMenu.svelte'
-  import CommandsList from './CommandsList.svelte'
-  import { GroupType } from '../managers/groupManager/groupManager.svelte.ts'
-  
-  function isModF(e: KeyboardEvent) {
-    const isMod = e.metaKey || e.ctrlKey
-    return isMod && !e.altKey && !e.shiftKey && e.key.toLowerCase() === 'f'
-  }
+// Props and Context
+interface Props {
+	plugin: KeyboardAnalyzerPlugin;
+	view: ShortcutsView;
+}
 
-  // Props and Context
-  interface Props {
-    plugin: KeyboardAnalyzerPlugin
-    view: ShortcutsView
-  }
+let { plugin, view }: Props = $props();
 
-  let { plugin, view }: Props = $props()
+// Managers and stores
+const commandsManager: CommandsManager = plugin.commandsManager;
+const settingsManager: SettingsManager = plugin.settingsManager;
+const visualKeyboardManager = new VisualKeyboardManager();
+const activeKeysStore = new ActiveKeysStore(plugin.app, visualKeyboardManager);
 
-  // Managers and stores
-  const commandsManager: CommandsManager = plugin.commandsManager
-  const visualKeyboardManager = new VisualKeyboardManager()
-  const activeKeysStore = new ActiveKeysStore(plugin.app, visualKeyboardManager)
+setContext("keyboard-analyzer-plugin", plugin);
+setContext("activeKeysStore", activeKeysStore);
+setContext("visualKeyboardManager", visualKeyboardManager);
+// Expose a live getter for whether physical listener is active to disable Alt-hover when active
+setContext("isPhysicalListenerActive", () => keyboardListenerIsActive);
 
-  setContext('keyboard-analyzer-plugin', plugin)
-  setContext('activeKeysStore', activeKeysStore)
-  setContext('visualKeyboardManager', visualKeyboardManager)
-  // Expose a live getter for whether physical listener is active to disable Alt-hover when active
-  setContext('isPhysicalListenerActive', () => keyboardListenerIsActive)
+// Always attach listeners; handlers no-op unless listener is active
+const down = (e: KeyboardEvent) => {
+	// Global UX shortcuts for this view
+	if (isModF(e)) {
+		e.preventDefault();
+		e.stopPropagation();
+		if (document.activeElement !== input) {
+			input?.focus();
+			logger.debug("[keys] Mod+F: focus search");
+		} else {
+			keyboardListenerIsActive = !keyboardListenerIsActive;
+			logger.debug("[keys] Mod+F: toggle listener", {
+				to: keyboardListenerIsActive,
+			});
+		}
+		return;
+	}
+	if (e.key === "Escape") {
+		e.preventDefault();
+		e.stopPropagation();
+		if (keyboardListenerIsActive) {
+			keyboardListenerIsActive = false;
+			input?.focus();
+			logger.debug("[keys] Esc: disable listener and focus search");
+		} else if (document.activeElement === input) {
+			// Unfocus search for accessibility
+			(document.activeElement as HTMLElement)?.blur();
+			logger.debug("[keys] Esc: blur search input");
+		}
+		return;
+	}
 
-  // Always attach listeners; handlers no-op unless listener is active
-  const down = (e: KeyboardEvent) => {
-    // Global UX shortcuts for this view
-    if (isModF(e)) {
-      e.preventDefault()
-      e.stopPropagation()
-      if (document.activeElement !== input) {
-        input?.focus()
-        logger.debug('[keys] Mod+F: focus search')
-      } else {
-        keyboardListenerIsActive = !keyboardListenerIsActive
-        logger.debug('[keys] Mod+F: toggle listener', { to: keyboardListenerIsActive })
-      }
-      return
-    }
-    if (e.key === 'Escape') {
-      e.preventDefault()
-      e.stopPropagation()
-      if (keyboardListenerIsActive) {
-        keyboardListenerIsActive = false
-        input?.focus()
-        logger.debug('[keys] Esc: disable listener and focus search')
-      } else if (document.activeElement === input) {
-        // Unfocus search for accessibility
-        ;(document.activeElement as HTMLElement)?.blur()
-        logger.debug('[keys] Esc: blur search input')
-      }
-      return
-    }
+	if (!keyboardListenerIsActive) {
+		logger.debug("[keys] ignored keydown (listener off)", e.key, e.code);
+		return;
+	}
+	logger.debug("[keys] keydown", { key: e.key, code: e.code });
+	activeKeysStore.handlePhysicalKeyDown(e);
+	logger.debug("[keys] state after keydown", activeKeysStore.state);
+};
+const up = (e: KeyboardEvent) => {
+	if (!keyboardListenerIsActive) {
+		logger.debug("[keys] ignored keyup (listener off)", e.key, e.code);
+		return;
+	}
+	logger.debug("[keys] keyup", { key: e.key, code: e.code });
+	activeKeysStore.handlePhysicalKeyUp(e);
+	logger.debug("[keys] state after keyup", activeKeysStore.state);
+};
+onMount(() => {
+	const w = window as unknown as Record<string, unknown>;
+	// Remove any stale listeners from previous mounts/reloads
+	const prevDown = w.__kb_analyzer_keys_down as
+		| ((e: KeyboardEvent) => void)
+		| undefined;
+	const prevUp = w.__kb_analyzer_keys_up as
+		| ((e: KeyboardEvent) => void)
+		| undefined;
+	if (prevDown) {
+		window.removeEventListener("keydown", prevDown);
+	}
+	if (prevUp) {
+		window.removeEventListener("keyup", prevUp);
+	}
+	// Attach fresh listeners and stash them on window for future cleanup
+	window.addEventListener("keydown", down, true);
+	window.addEventListener("keyup", up, true);
+	(w as Record<string, unknown>).__kb_analyzer_keys_down = down;
+	(w as Record<string, unknown>).__kb_analyzer_keys_up = up;
+	logger.debug("[keys] global listeners attached");
+	return () => {
+		window.removeEventListener("keydown", down, true);
+		window.removeEventListener("keyup", up, true);
+		if ((w as Record<string, unknown>).__kb_analyzer_keys_down === down)
+			(w as Record<string, unknown>).__kb_analyzer_keys_down = undefined;
+		if ((w as Record<string, unknown>).__kb_analyzer_keys_up === up)
+			(w as Record<string, unknown>).__kb_analyzer_keys_up = undefined;
+	};
+});
 
-    if (!keyboardListenerIsActive) {
-      logger.debug('[keys] ignored keydown (listener off)', e.key, e.code)
-      return
-    }
-    logger.debug('[keys] keydown', { key: e.key, code: e.code })
-    activeKeysStore.handlePhysicalKeyDown(e)
-    logger.debug('[keys] state after keydown', activeKeysStore.state)
-  }
-  const up = (e: KeyboardEvent) => {
-    if (!keyboardListenerIsActive) {
-      logger.debug('[keys] ignored keyup (listener off)', e.key, e.code)
-      return
-    }
-    logger.debug('[keys] keyup', { key: e.key, code: e.code })
-    activeKeysStore.handlePhysicalKeyUp(e)
-    logger.debug('[keys] state after keyup', activeKeysStore.state)
-  }
-  onMount(() => {
-    const w = window as unknown as Record<string, unknown>
-    // Remove any stale listeners from previous mounts/reloads
-    const prevDown = w.__kb_analyzer_keys_down as ((e: KeyboardEvent) => void) | undefined
-    const prevUp = w.__kb_analyzer_keys_up as ((e: KeyboardEvent) => void) | undefined
-    if (prevDown) {
-      window.removeEventListener('keydown', prevDown)
-    }
-    if (prevUp) {
-      window.removeEventListener('keyup', prevUp)
-    }
-    // Attach fresh listeners and stash them on window for future cleanup
-    window.addEventListener('keydown', down, true)
-    window.addEventListener('keyup', up, true)
-    ;(w as any).__kb_analyzer_keys_down = down
-    ;(w as any).__kb_analyzer_keys_up = up
-    logger.debug('[keys] global listeners attached')
-    return () => {
-      window.removeEventListener('keydown', down, true)
-      window.removeEventListener('keyup', up, true)
-      if ((w as any).__kb_analyzer_keys_down === down) (w as any).__kb_analyzer_keys_down = undefined
-      if ((w as any).__kb_analyzer_keys_up === up) (w as any).__kb_analyzer_keys_up = undefined
-    }
-  })
+// Reactive variables
+let viewWidth = $state(0);
+let viewMode = $state("desktop");
+let search = $state("");
+let input: HTMLInputElement | undefined = $state();
+let keyboardListenerIsActive = $state(false);
 
-  // Reactive variables
-  let viewWidth = $state(0)
-  let viewMode = $state('desktop')
-  let search = $state('')
-  let input: HTMLInputElement | undefined = $state()
-  let keyboardListenerIsActive = $state(false)
+let selectedGroupID = $state(
+	(plugin.settingsManager.settings.lastOpenedGroupId as string) ||
+		GroupType.All,
+);
 
-  let selectedGroupID = $state(
-    (plugin.settingsManager.settings.lastOpenedGroupId as string) || GroupType.All
-  )
+let visibleCommands = $state<commandEntry[]>([]);
+let searchCommandsCount = $derived(visibleCommands.length);
+let searchHotkeysCount = $derived(
+	visibleCommands.reduce((count, command) => count + command.hotkeys.length, 0),
+);
 
-  let visibleCommands = $state<commandEntry[]>([])
-  let searchCommandsCount = $derived(visibleCommands.length)
-  let searchHotkeysCount = $derived(
-    visibleCommands.reduce(
-      (count, command) => count + command.hotkeys.length,
-      0,
-    ),
-  )
+let heatmapScope = $derived.by(() => {
+	settingsManager.settings.heatmapScope;
+	return (
+		(settingsManager.settings.heatmapScope as "filtered" | "all") || "filtered"
+	);
+});
 
-  $effect(() => {
-    visibleCommands = commandsManager.filterCommands(
-      search,
-      activeKeysStore.ActiveModifiers,
-      activeKeysStore.ActiveKey,
-      selectedGroupID,
-    )
-    return
-  })
+$effect(() => {
+	visibleCommands = commandsManager.filterCommands(
+		search,
+		activeKeysStore.ActiveModifiers,
+		activeKeysStore.ActiveKey,
+		selectedGroupID,
+	);
+	return;
+});
 
-  // Persist last opened group for future opens.
-  // Avoid creating a reactive dependency on settings to prevent rerender loops.
-  let lastPersistedGroup = $state(
-    (plugin.settingsManager.getSetting('lastOpenedGroupId') as string) || GroupType.All
-  )
-  let persistTimer: ReturnType<typeof setTimeout> | null = null
-  $effect(() => {
-    // Only react to local selectedGroupID changes
-    const next = selectedGroupID
-    if (next && next !== lastPersistedGroup) {
-      if (persistTimer) clearTimeout(persistTimer)
-      // Debounce to coalesce rapid group switches and reduce save churn
-      persistTimer = setTimeout(() => {
-        plugin.settingsManager.updateSettings({ lastOpenedGroupId: next })
-        lastPersistedGroup = next
-      }, 200)
-    }
-  })
+$effect(() => {
+	const groupFilters = plugin.groupManager.getGroupSettings(selectedGroupID);
+	const includeSystem = groupFilters.DisplaySystemShortcuts;
+	const commands =
+		heatmapScope === "all"
+			? commandsManager
+					.getCommandsForGroup(GroupType.All)
+					.filter(
+						(cmd) => includeSystem || cmd.pluginName !== "System Shortcuts",
+					)
+			: visibleCommands;
+	visualKeyboardManager.calculateAndAssignWeights(commands);
+});
 
-  $effect(() => {
-    input?.focus()
-  })
+// Persist last opened group for future opens.
+// Avoid creating a reactive dependency on settings to prevent rerender loops.
+let lastPersistedGroup = $state(
+	(plugin.settingsManager.getSetting("lastOpenedGroupId") as string) ||
+		GroupType.All,
+);
+let persistTimer: ReturnType<typeof setTimeout> | null = null;
+$effect(() => {
+	// Only react to local selectedGroupID changes
+	const next = selectedGroupID;
+	if (next && next !== lastPersistedGroup) {
+		if (persistTimer) clearTimeout(persistTimer);
+		// Debounce to coalesce rapid group switches and reduce save churn
+		persistTimer = setTimeout(() => {
+			plugin.settingsManager.updateSettings({ lastOpenedGroupId: next });
+			lastPersistedGroup = next;
+		}, 200);
+	}
+});
 
-  $effect(() => {
-    handleResize(viewWidth)
-  })
+$effect(() => {
+	input?.focus();
+});
 
-  // Keep visual keyboard in sync when active key/modifiers change
-  $effect(() => {
-    visualKeyboardManager.updateVisualState(
-      activeKeysStore.ActiveKey,
-      activeKeysStore.ActiveModifiers,
-    )
-  })
+$effect(() => {
+	handleResize(viewWidth);
+});
 
-  // function handleGroupSelection(event: CustomEvent<string>) {
-  //   selectedGroup = event.detail
-  //   handleSearch()
-  // }
+// Keep visual keyboard in sync when active key/modifiers change
+$effect(() => {
+	visualKeyboardManager.updateVisualState(
+		activeKeysStore.ActiveKey,
+		activeKeysStore.ActiveModifiers,
+	);
+});
 
-  // Effect to trigger search on group change (effects are triggered each time the values of the variables form inside the effect change)
+// function handleGroupSelection(event: CustomEvent<string>) {
+//   selectedGroup = event.detail
+//   handleSearch()
+// }
 
-  // Helper functions
-  // function updateSearchCounts() {
-  //   searchCommandsCount = visibleCommands.length
-  //   searchHotkeysCount = visibleCommands.reduce(
-  //     (count, command) => count + command.hotkeys.length,
-  //     0
-  //   )
-  // }
+// Effect to trigger search on group change (effects are triggered each time the values of the variables form inside the effect change)
 
-  function handleResize(width: number) {
-    if (width >= 1400) viewMode = 'xxl'
-    else if (width >= 1200) viewMode = 'xl'
-    else if (width >= 992) viewMode = 'lg'
-    else if (width >= 768) viewMode = 'md'
-    else if (width >= 576) viewMode = 'sm'
-    else viewMode = 'xs'
-  }
+// Helper functions
+// function updateSearchCounts() {
+//   searchCommandsCount = visibleCommands.length
+//   searchHotkeysCount = visibleCommands.reduce(
+//     (count, command) => count + command.hotkeys.length,
+//     0
+//   )
+// }
 
-  // Event handlers
-  function handleSearch(
-    search: string,
-    activeModifiers: string[],
-    activeKey: string,
-    selectedGroup?: string,
-  ) {
-    visibleCommands = commandsManager.filterCommands(
-      search,
-      activeModifiers,
-      activeKey,
-      selectedGroup,
-    )
-  }
+function handleResize(width: number) {
+	if (width >= 1400) viewMode = "xxl";
+	else if (width >= 1200) viewMode = "xl";
+	else if (width >= 992) viewMode = "lg";
+	else if (width >= 768) viewMode = "md";
+	else if (width >= 576) viewMode = "sm";
+	else viewMode = "xs";
+}
 
-  function handlePluginNameClicked(pluginName: string) {
-    if (!search) {
-      input?.focus()
-      search = pluginName
-    } else if (search.startsWith(pluginName)) {
-      search = search.replace(pluginName, '')
-    } else {
-      search = pluginName + search
-    }
-  }
+// Event handlers
+function handleSearch(
+	search: string,
+	activeModifiers: string[],
+	activeKey: string,
+	selectedGroup?: string,
+) {
+	visibleCommands = commandsManager.filterCommands(
+		search,
+		activeModifiers,
+		activeKey,
+		selectedGroup,
+	);
+}
 
-  function handleDuplicateHotkeyClicked(hotkey: hotkeyEntry) {
-    const { modifiers, key } = hotkey
-    const duplicativeModifiers = convertModifiers(modifiers)
+function handlePluginNameClicked(pluginName: string) {
+	if (!search) {
+		input?.focus();
+		search = pluginName;
+	} else if (search.startsWith(pluginName)) {
+		search = search.replace(pluginName, "");
+	} else {
+		search = pluginName + search;
+	}
+}
 
-    if (
-      activeKeysStore.ActiveModifiers.every((modifier) =>
-        duplicativeModifiers.includes(modifier as Modifier),
-      ) &&
-      activeKeysStore.ActiveKey.toLowerCase() === key.toLowerCase()
-    ) {
-      activeKeysStore.reset()
-    } else {
-      activeKeysStore.ActiveModifiers = duplicativeModifiers
-      activeKeysStore.ActiveKey = key
-      search = ''
-    }
-  }
+function handleDuplicateHotkeyClicked(hotkey: hotkeyEntry) {
+	const { modifiers, key } = hotkey;
+	const duplicativeModifiers = convertModifiers(modifiers);
 
-  function handleStarIconClicked(commandId: string) {
-    commandsManager.toggleFeaturedCommand(commandId)
-  }
+	if (
+		activeKeysStore.ActiveModifiers.every((modifier) =>
+			duplicativeModifiers.includes(modifier as Modifier),
+		) &&
+		activeKeysStore.ActiveKey.toLowerCase() === key.toLowerCase()
+	) {
+		activeKeysStore.reset();
+	} else {
+		activeKeysStore.ActiveModifiers = duplicativeModifiers;
+		activeKeysStore.ActiveKey = key;
+		search = "";
+	}
+}
+
+function handleStarIconClicked(commandId: string) {
+	commandsManager.toggleFeaturedCommand(commandId);
+}
 </script>
 
 <div
@@ -262,7 +287,7 @@
   bind:offsetWidth={viewWidth}
 >
   <div id="keyboard-preview-view">
-    <KeyboardLayoutComponent {visibleCommands} />
+    <KeyboardLayoutComponent />
   </div>
   <div class="shortcuts-wrapper">
     <SearchMenu

--- a/src/managers/settingsManager/settingsManager.d.ts
+++ b/src/managers/settingsManager/settingsManager.d.ts
@@ -1,70 +1,71 @@
 export interface PluginSettings {
-  showStatusBarItem: boolean
-  defaultFilterSettings: FilterSettings
-  filters: {
-    isUnifiedAcrossGroups: boolean
-    filterSettings: FilterSettings
-  }
-  featuredCommandIDs: string[]
-  commandGroups: CGroup[]
-  lastOpenedGroupId?: string
-  pinKeyboardPanel?: boolean
-  // Developer options (non-breaking defaults)
-  enableDeveloperOptions?: boolean
-  devLoggingEnabled?: boolean
-  emulatedOS?: 'none' | 'windows' | 'macos' | 'linux'
-  // Debuggable presentation toggle for key display names
-  useBakedKeyNames?: boolean
+	showStatusBarItem: boolean;
+	defaultFilterSettings: FilterSettings;
+	filters: {
+		isUnifiedAcrossGroups: boolean;
+		filterSettings: FilterSettings;
+	};
+	featuredCommandIDs: string[];
+	commandGroups: CGroup[];
+	lastOpenedGroupId?: string;
+	pinKeyboardPanel?: boolean;
+	heatmapScope?: "filtered" | "all";
+	// Developer options (non-breaking defaults)
+	enableDeveloperOptions?: boolean;
+	devLoggingEnabled?: boolean;
+	emulatedOS?: "none" | "windows" | "macos" | "linux";
+	// Debuggable presentation toggle for key display names
+	useBakedKeyNames?: boolean;
 }
 
 export enum FilterSettingsKeys {
-  StrictModifierMatch = 'StrictModifierMatch',
-  ViewWOhotkeys = 'ViewWOhotkeys',
-  OnlyCustom = 'OnlyCustom',
-  OnlyDuplicates = 'OnlyDuplicates',
-  FeaturedFirst = 'FeaturedFirst',
-  HighlightBuiltIns = 'HighlightBuiltIns',
-  GroupByPlugin = 'GroupByPlugin',
-  HighlightCustom = 'HighlightCustom',
-  HighlightDuplicates = 'HighlightDuplicates',
-  DisplayIDs = 'DisplayIDs',
-  ShowPluginBadges = 'ShowPluginBadges',
-  DisplayGroupAssignment = 'DisplayGroupAssignment',
-  DisplayInternalModules = 'DisplayInternalModules',
-  DisplaySystemShortcuts = 'DisplaySystemShortcuts',
+	StrictModifierMatch = "StrictModifierMatch",
+	ViewWOhotkeys = "ViewWOhotkeys",
+	OnlyCustom = "OnlyCustom",
+	OnlyDuplicates = "OnlyDuplicates",
+	FeaturedFirst = "FeaturedFirst",
+	HighlightBuiltIns = "HighlightBuiltIns",
+	GroupByPlugin = "GroupByPlugin",
+	HighlightCustom = "HighlightCustom",
+	HighlightDuplicates = "HighlightDuplicates",
+	DisplayIDs = "DisplayIDs",
+	ShowPluginBadges = "ShowPluginBadges",
+	DisplayGroupAssignment = "DisplayGroupAssignment",
+	DisplayInternalModules = "DisplayInternalModules",
+	DisplaySystemShortcuts = "DisplaySystemShortcuts",
 }
 
 // View/presentation-related subset to separate UI concerns from filtering
 export enum ViewSettingsKeys {
-  FeaturedFirst = 'FeaturedFirst',
-  GroupByPlugin = 'GroupByPlugin',
-  HighlightCustom = 'HighlightCustom',
-  HighlightDuplicates = 'HighlightDuplicates',
-  DisplayIDs = 'DisplayIDs',
-  HighlightBuiltIns = 'HighlightBuiltIns',
-  ShowPluginBadges = 'ShowPluginBadges',
+	FeaturedFirst = "FeaturedFirst",
+	GroupByPlugin = "GroupByPlugin",
+	HighlightCustom = "HighlightCustom",
+	HighlightDuplicates = "HighlightDuplicates",
+	DisplayIDs = "DisplayIDs",
+	HighlightBuiltIns = "HighlightBuiltIns",
+	ShowPluginBadges = "ShowPluginBadges",
 }
 
 type FilterSettings = {
-  [key in FilterSettingsKeys]: boolean
-}
+	[key in FilterSettingsKeys]: boolean;
+};
 
 type CGroupSettingTitles = {
-  [key in FilterSettingsKeys]: string
-}
+	[key in FilterSettingsKeys]: string;
+};
 
 export interface CGroup {
-  id: string | GroupType // This is the sanitized group name
-  name: string // This is the original group name
-  commandIds: string[]
-  excludedModules: string[]
-  filterSettings: CGroupFilterSettings
+	id: string | GroupType; // This is the sanitized group name
+	name: string; // This is the original group name
+	commandIds: string[];
+	excludedModules: string[];
+	filterSettings: CGroupFilterSettings;
 }
 
 export interface CGroupFilterSettings extends FilterSettings {}
 
 export enum GroupType {
-  All = 'all',
-  Featured = 'featured',
-  Recent = 'recent',
+	All = "all",
+	Featured = "featured",
+	Recent = "recent",
 }

--- a/src/managers/settingsManager/settingsManager.svelte.ts
+++ b/src/managers/settingsManager/settingsManager.svelte.ts
@@ -1,201 +1,229 @@
-import type KeyboardAnalyzerPlugin from '../../main'
+import type KeyboardAnalyzerPlugin from "../../main";
+import logger from "../../utils/logger";
 import {
-  type PluginSettings,
-  type FilterSettings,
-  type CGroup,
-  type CGroupFilterSettings,
-  GroupType,
-} from './settingsManager.d'
-import { setDevLoggingEnabled, setEmulatedOS, setLogLevel } from '../../utils/runtimeConfig'
-import logger from '../../utils/logger'
+	setDevLoggingEnabled,
+	setEmulatedOS,
+	setLogLevel,
+} from "../../utils/runtimeConfig";
+import {
+	type CGroup,
+	type CGroupFilterSettings,
+	type FilterSettings,
+	GroupType,
+	type PluginSettings,
+} from "./settingsManager.d";
 
 const DEFAULT_FILTER_SETTINGS: FilterSettings = {
-  StrictModifierMatch: true,
-  ViewWOhotkeys: true,
-  OnlyCustom: false,
-  OnlyDuplicates: false,
-  FeaturedFirst: false,
-  HighlightCustom: false,
-  HighlightDuplicates: false,
-  HighlightBuiltIns: false,
-  DisplayIDs: false,
-  ShowPluginBadges: true,
-  GroupByPlugin: false,
-  DisplayGroupAssignment: false,
-  DisplayInternalModules: true,
-  DisplaySystemShortcuts: false,
-}
+	StrictModifierMatch: true,
+	ViewWOhotkeys: true,
+	OnlyCustom: false,
+	OnlyDuplicates: false,
+	FeaturedFirst: false,
+	HighlightCustom: false,
+	HighlightDuplicates: false,
+	HighlightBuiltIns: false,
+	DisplayIDs: false,
+	ShowPluginBadges: true,
+	GroupByPlugin: false,
+	DisplayGroupAssignment: false,
+	DisplayInternalModules: true,
+	DisplaySystemShortcuts: false,
+};
 
 const DEFAULT_PLUGIN_SETTINGS: PluginSettings = {
-  showStatusBarItem: true,
-  defaultFilterSettings: DEFAULT_FILTER_SETTINGS,
-  filters: {
-    isUnifiedAcrossGroups: false,
-    filterSettings: DEFAULT_FILTER_SETTINGS,
-  },
-  featuredCommandIDs: [],
-  commandGroups: [],
-  lastOpenedGroupId: 'all',
-  pinKeyboardPanel: false,
-  enableDeveloperOptions: false,
-  devLoggingEnabled: false,
-  emulatedOS: 'none',
-  useBakedKeyNames: true,
-}
+	showStatusBarItem: true,
+	defaultFilterSettings: DEFAULT_FILTER_SETTINGS,
+	filters: {
+		isUnifiedAcrossGroups: false,
+		filterSettings: DEFAULT_FILTER_SETTINGS,
+	},
+	featuredCommandIDs: [],
+	commandGroups: [],
+	lastOpenedGroupId: "all",
+	pinKeyboardPanel: false,
+	heatmapScope: "filtered",
+	enableDeveloperOptions: false,
+	devLoggingEnabled: false,
+	emulatedOS: "none",
+	useBakedKeyNames: true,
+};
 
 export default class SettingsManager {
-  private static instance: SettingsManager | null = null
-  private plugin: KeyboardAnalyzerPlugin
-  public settings: PluginSettings = $state(DEFAULT_PLUGIN_SETTINGS)
-  // Serialize and debounce saves to avoid partial writes and loops
-  private saveTimer: ReturnType<typeof setTimeout> | null = null
-  private saveInProgress = false
-  private pendingAfterSave = false
+	private static instance: SettingsManager | null = null;
+	private plugin: KeyboardAnalyzerPlugin;
+	public settings: PluginSettings = $state(DEFAULT_PLUGIN_SETTINGS);
+	// Serialize and debounce saves to avoid partial writes and loops
+	private saveTimer: ReturnType<typeof setTimeout> | null = null;
+	private saveInProgress = false;
+	private pendingAfterSave = false;
 
-  private constructor(plugin: KeyboardAnalyzerPlugin) {
-    this.plugin = plugin
-  }
+	private constructor(plugin: KeyboardAnalyzerPlugin) {
+		this.plugin = plugin;
+	}
 
-  static getInstance(plugin: KeyboardAnalyzerPlugin): SettingsManager {
-    if (!SettingsManager.instance) {
-      SettingsManager.instance = new SettingsManager(plugin)
-    }
-    return SettingsManager.instance
-  }
+	static getInstance(plugin: KeyboardAnalyzerPlugin): SettingsManager {
+		if (!SettingsManager.instance) {
+			SettingsManager.instance = new SettingsManager(plugin);
+		}
+		return SettingsManager.instance;
+	}
 
-  // public get settings(): PluginSettings {
-  //   return this.settings
-  // }
+	// public get settings(): PluginSettings {
+	//   return this.settings
+	// }
 
-  getSetting<K extends keyof PluginSettings>(key: K): PluginSettings[K] {
-    return this.settings[key]
-  }
+	getSetting<K extends keyof PluginSettings>(key: K): PluginSettings[K] {
+		return this.settings[key];
+	}
 
-  async loadSettings(): Promise<void> {
-    try {
-      const loadedData = await this.plugin.loadData()
-      if (loadedData && typeof loadedData === 'object') {
-        this.settings = { ...DEFAULT_PLUGIN_SETTINGS, ...loadedData }
-      } else {
-        // If file is empty or invalid, reset to defaults and persist to repair data.json
-        this.settings = { ...DEFAULT_PLUGIN_SETTINGS }
-        await this.plugin.saveData(this.settings)
-      }
-      // Apply runtime flags from settings
-      setDevLoggingEnabled(!!this.settings.devLoggingEnabled)
-      setEmulatedOS((this.settings.emulatedOS || 'none') as 'none' | 'windows' | 'macos' | 'linux')
-      setLogLevel('debug')
-    } catch (error) {
-      logger.error('Failed to Plugin load settings:', error)
-      // Repair by writing defaults so Obsidian stops failing JSON.parse on next boot
-      try {
-        this.settings = { ...DEFAULT_PLUGIN_SETTINGS }
-        await this.plugin.saveData(this.settings)
-        logger.warn('Settings file was invalid; wrote defaults to repair data.json')
-      } catch (saveErr) {
-        logger.error('Failed to write default settings after load error:', saveErr)
-      }
-    }
-  }
+	async loadSettings(): Promise<void> {
+		try {
+			const loadedData = await this.plugin.loadData();
+			if (loadedData && typeof loadedData === "object") {
+				this.settings = { ...DEFAULT_PLUGIN_SETTINGS, ...loadedData };
+			} else {
+				// If file is empty or invalid, reset to defaults and persist to repair data.json
+				this.settings = { ...DEFAULT_PLUGIN_SETTINGS };
+				await this.plugin.saveData(this.settings);
+			}
+			// Apply runtime flags from settings
+			setDevLoggingEnabled(!!this.settings.devLoggingEnabled);
+			setEmulatedOS(
+				(this.settings.emulatedOS || "none") as
+					| "none"
+					| "windows"
+					| "macos"
+					| "linux",
+			);
+			setLogLevel("debug");
+		} catch (error) {
+			logger.error("Failed to Plugin load settings:", error);
+			// Repair by writing defaults so Obsidian stops failing JSON.parse on next boot
+			try {
+				this.settings = { ...DEFAULT_PLUGIN_SETTINGS };
+				await this.plugin.saveData(this.settings);
+				logger.warn(
+					"Settings file was invalid; wrote defaults to repair data.json",
+				);
+			} catch (saveErr) {
+				logger.error(
+					"Failed to write default settings after load error:",
+					saveErr,
+				);
+			}
+		}
+	}
 
-  async saveSettings(): Promise<void> {
-    // Expose direct save if needed, but try to prefer scheduleSave
-    try {
-      await this.plugin.saveData(this.settings)
-    } catch (error) {
-      logger.error('Failed to Plugin save settings:', error)
-    }
-  }
+	async saveSettings(): Promise<void> {
+		// Expose direct save if needed, but try to prefer scheduleSave
+		try {
+			await this.plugin.saveData(this.settings);
+		} catch (error) {
+			logger.error("Failed to Plugin save settings:", error);
+		}
+	}
 
-  private scheduleSave(delay = 150) {
-    if (this.saveTimer) {
-      clearTimeout(this.saveTimer)
-    }
-    this.saveTimer = setTimeout(() => {
-      this.saveTimer = null
-      this.flushSaveQueue()
-    }, delay)
-  }
+	private scheduleSave(delay = 150) {
+		if (this.saveTimer) {
+			clearTimeout(this.saveTimer);
+		}
+		this.saveTimer = setTimeout(() => {
+			this.saveTimer = null;
+			this.flushSaveQueue();
+		}, delay);
+	}
 
-  private async flushSaveQueue() {
-    if (this.saveInProgress) {
-      // One more save after current finishes
-      this.pendingAfterSave = true
-      return
-    }
-    this.saveInProgress = true
-    try {
-      await this.plugin.saveData(this.settings)
-    } catch (error) {
-      logger.error('Failed to save settings (flush):', error)
-    } finally {
-      this.saveInProgress = false
-      if (this.pendingAfterSave) {
-        this.pendingAfterSave = false
-        // Coalesce rapid updates into one final write
-        this.scheduleSave(50)
-      }
-    }
-  }
+	private async flushSaveQueue() {
+		if (this.saveInProgress) {
+			// One more save after current finishes
+			this.pendingAfterSave = true;
+			return;
+		}
+		this.saveInProgress = true;
+		try {
+			await this.plugin.saveData(this.settings);
+		} catch (error) {
+			logger.error("Failed to save settings (flush):", error);
+		} finally {
+			this.saveInProgress = false;
+			if (this.pendingAfterSave) {
+				this.pendingAfterSave = false;
+				// Coalesce rapid updates into one final write
+				this.scheduleSave(50);
+			}
+		}
+	}
 
-  /**
-   * Public: Flush any pending debounced saves and serialize one final write.
-   * Used on plugin unload to reduce chances of truncated JSON.
-   */
-  public async flushAllSaves(): Promise<void> {
-    if (this.saveTimer) {
-      clearTimeout(this.saveTimer)
-      this.saveTimer = null
-    }
-    // If a save is already in progress, mark that we want one more and wait for the queue
-    if (this.saveInProgress) {
-      this.pendingAfterSave = true
-      // Poll-wait up to ~1s for the in-flight save to finish, then the queued one to schedule
-      const start = Date.now()
-      while (this.saveInProgress && Date.now() - start < 1000) {
-        await new Promise((r) => setTimeout(r, 25))
-      }
-    }
-    // Perform an immediate flush write
-    try {
-      await this.plugin.saveData(this.settings)
-    } catch (err) {
-      logger.error('Failed to flush settings on unload:', err)
-    }
-  }
+	/**
+	 * Public: Flush any pending debounced saves and serialize one final write.
+	 * Used on plugin unload to reduce chances of truncated JSON.
+	 */
+	public async flushAllSaves(): Promise<void> {
+		if (this.saveTimer) {
+			clearTimeout(this.saveTimer);
+			this.saveTimer = null;
+		}
+		// If a save is already in progress, mark that we want one more and wait for the queue
+		if (this.saveInProgress) {
+			this.pendingAfterSave = true;
+			// Poll-wait up to ~1s for the in-flight save to finish, then the queued one to schedule
+			const start = Date.now();
+			while (this.saveInProgress && Date.now() - start < 1000) {
+				await new Promise((r) => setTimeout(r, 25));
+			}
+		}
+		// Perform an immediate flush write
+		try {
+			await this.plugin.saveData(this.settings);
+		} catch (err) {
+			logger.error("Failed to flush settings on unload:", err);
+		}
+	}
 
-  updateSettings(newSettings: Partial<PluginSettings>): void {
-    // Shallow equality check to avoid redundant writes/rerenders
-    let changed = false
-    const next = { ...this.settings }
-    for (const [k, v] of Object.entries(newSettings) as [keyof PluginSettings, unknown][]) {
-      if (next[k] !== v) {
-        // @ts-expect-error generic write into settings shape
-        next[k] = v
-        changed = true
-      }
-    }
-    if (!changed) return
-    this.settings = next
-    // Update runtime flags when relevant settings change
-    if ('devLoggingEnabled' in newSettings) {
-      setDevLoggingEnabled(!!this.settings.devLoggingEnabled)
-      logger.info('Dev logging', this.settings.devLoggingEnabled ? 'enabled' : 'disabled')
-    }
-    if ('emulatedOS' in newSettings) {
-      setEmulatedOS((this.settings.emulatedOS || 'none') as 'none' | 'windows' | 'macos' | 'linux')
-      logger.info('Emulated OS set to', this.settings.emulatedOS || 'none')
-    }
-    this.scheduleSave()
-  }
+	updateSettings(newSettings: Partial<PluginSettings>): void {
+		// Shallow equality check to avoid redundant writes/rerenders
+		let changed = false;
+		const next = { ...this.settings };
+		for (const [k, v] of Object.entries(newSettings) as [
+			keyof PluginSettings,
+			unknown,
+		][]) {
+			if (next[k] !== v) {
+				// @ts-expect-error generic write into settings shape
+				next[k] = v;
+				changed = true;
+			}
+		}
+		if (!changed) return;
+		this.settings = next;
+		// Update runtime flags when relevant settings change
+		if ("devLoggingEnabled" in newSettings) {
+			setDevLoggingEnabled(!!this.settings.devLoggingEnabled);
+			logger.info(
+				"Dev logging",
+				this.settings.devLoggingEnabled ? "enabled" : "disabled",
+			);
+		}
+		if ("emulatedOS" in newSettings) {
+			setEmulatedOS(
+				(this.settings.emulatedOS || "none") as
+					| "none"
+					| "windows"
+					| "macos"
+					| "linux",
+			);
+			logger.info("Emulated OS set to", this.settings.emulatedOS || "none");
+		}
+		this.scheduleSave();
+	}
 
-  // Getters and setters for reactive properties
-  get showStatusBarItem(): boolean {
-    return this.settings.showStatusBarItem
-  }
+	// Getters and setters for reactive properties
+	get showStatusBarItem(): boolean {
+		return this.settings.showStatusBarItem;
+	}
 
-  set showStatusBarItem(value: boolean) {
-    this.settings.showStatusBarItem = value
-    this.scheduleSave()
-  }
+	set showStatusBarItem(value: boolean) {
+		this.settings.showStatusBarItem = value;
+		this.scheduleSave();
+	}
 }

--- a/tasks/25081002-fix-show-all-heatmap-scope.md
+++ b/tasks/25081002-fix-show-all-heatmap-scope.md
@@ -1,8 +1,8 @@
 ---
 title: Fix "Show: all" heatmap scope in group view
-status: todo
+status: in_progress
 owner: "@agent"
-updated: 2025-08-10 03:45 UTC
+updated: 2025-08-11 13:00 UTC
 related:
   - [[25080914-hotkey-groups]]
 ---
@@ -47,4 +47,8 @@ When a user selects a manual group, the command list is scoped to that group. Ho
 
 ## Notes
 - Keep current focus on hotkey groups; this task is queued to refine heatmap behavior without blocking current work.
+
+## Progress Log
+- [2025-08-11 12:00 UTC] Persisted heatmap scope setting and filtered system shortcuts when hidden.
+- [2025-08-11 13:00 UTC] Moved heatmap scope toggle into View dropdown and centralized dataset calculation.
 

--- a/tasks/25081107-SPRINT-aug-11-2025-ux-heatmap-bugs.md
+++ b/tasks/25081107-SPRINT-aug-11-2025-ux-heatmap-bugs.md
@@ -1,0 +1,22 @@
+---
+title: Sprint - Aug 11 2025 UX heatmap bugs
+status: in_progress
+owner: "@agent"
+updated: 2025-08-11 13:00 UTC
+related:
+  - [[25081002-fix-show-all-heatmap-scope]]
+---
+
+## Context
+Track fixes for heatmap algorithm and related UX bugs.
+
+## Decisions
+- [2025-08-11] Introduced persistent heatmap scope setting and ensured global scope respects DisplaySystemShortcuts.
+- [2025-08-11] Moved heatmap scope toggle into View dropdown.
+
+## Next Steps
+- [ ] Verify algorithm across groups and large datasets.
+- [x] Move heatmap scope toggle into View dropdown.
+
+## Links
+- [[25081002-fix-show-all-heatmap-scope]]


### PR DESCRIPTION
## Summary
- expose persistent heatmap scope toggle in SearchMenu View dropdown
- centralize heatmap dataset calculation in KeyboardComponent
- track sprint progress for UX heatmap bugs

## Testing
- `npx -y @biomejs/biome@1.9.2 check src/components/KeyboardComponent.svelte src/components/KeyboardLayoutComponent.svelte src/components/SearchMenu.svelte tasks/25081002-fix-show-all-heatmap-scope.md tasks/25081107-SPRINT-aug-11-2025-ux-heatmap-bugs.md`
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_689a2ba3177483238e4aeec05686a8b4