### PR TITLE
fix: clamp add-to-group popover to viewport

### DIFF
--- a/src/components/AddToGroupPopover.svelte
+++ b/src/components/AddToGroupPopover.svelte
@@ -17,6 +17,7 @@
   let search = $state('')
   let newGroupName = $state('')
   let placeAbove = $state(false)
+  let offsetX = $state(0)
   let rootEl: HTMLDivElement | null = null
 
   function filteredGroups() {
@@ -44,22 +45,30 @@
   }
 
   onMount(() => {
-    // Flip above if there is not enough space below
+    // Flip above if there is not enough space below and clamp horizontally
     try {
       const el = rootEl
       if (!el) return
       const rect = el.getBoundingClientRect()
       const viewportH =
         window.innerHeight || document.documentElement.clientHeight
+      const viewportW =
+        window.innerWidth || document.documentElement.clientWidth
       const spaceBelow = viewportH - rect.top
       // heuristic threshold
       placeAbove = spaceBelow < 260
+
+      const overflowRight = rect.right - viewportW
+      const overflowLeft = rect.left
+      if (overflowRight > 0) offsetX = -overflowRight - 8
+      if (overflowLeft < 0) offsetX += -overflowLeft + 8
     } catch {}
   })
 </script>
 
 <div
   class="kb-popover {placeAbove ? 'is-above' : 'is-below'}"
+  style="transform: translateX({offsetX}px);"
   use:clickOutside
   onclick_outside={onClose}
   role="dialog"

--- a/tasks/25081103-fix-popover-overflow.md
+++ b/tasks/25081103-fix-popover-overflow.md
@@ -1,8 +1,8 @@
 ---
 title: Fix overflow/cropping of in-place pop-ups and dropdowns
-status: todo
+status: in_progress
 owner: '@agent'
-updated: 2025-08-11 12:00 UTC
+updated: 2025-08-11 19:15 UTC
 related:
   - [[25080913-SPRINT-list-of-bugs-and-new-feature-requests]]
 ---
@@ -27,12 +27,13 @@ Dropdowns and popovers are cropped or overflow when near pane/window edges. Ensu
 
 ## Decisions
 
-- [2025-08-11] Pending — adopt a positioning utility (e.g., Floating UI) vs. custom logic.
+- [2025-08-11] Opted for custom horizontal clamping in `AddToGroupPopover`; utility adoption still under review.
 
 ## Next Steps
 
 - [ ] Audit current measurement/position code; list edge cases (narrow sidebars, bottom edge, RTL).
 - [ ] If approved, integrate `@floating-ui/dom` for flip/shift/offset middleware; otherwise enhance custom logic.
+- [x] Add horizontal clamping in `AddToGroupPopover` to keep popover within viewport.
 - [ ] Add resize/scroll observers to recompute positions.
 - [ ] Verify clickOutside works with portals and doesn't interfere with focus.
 - [ ] Manual test in narrow panes and near edges (top/bottom/left/right).

--- a/tasks/25081107-SPRINT-aug-11-2025-ux-heatmap-bugs.md
+++ b/tasks/25081107-SPRINT-aug-11-2025-ux-heatmap-bugs.md
@@ -2,7 +2,7 @@
 title: SPRINT — Aug 11, 2025: Small-screen UX, Heatmap tuning, Bugfixes
 status: in_progress
 owner: "@agent"
-updated: 2025-08-11 12:30 UTC
+updated: 2025-08-11 19:15 UTC
 related:
   - [[25081101-redesign-manage-groups-modal]]
   - [[25081102-command-search-in-manage-groups]]
@@ -55,3 +55,4 @@ Coordinate parallel work across UX improvements for small screens, heatmap weigh
 
 - Please append brief progress updates to each linked task and this sprint note with timestamps.
 - Keep scope limited to acceptance criteria; spin off follow-ups as new tasks and link them here.
+- [2025-08-11] Implemented horizontal clamping for `AddToGroupPopover` to keep popover within viewport. (rel: [[25081103-fix-popover-overflow]])


### PR DESCRIPTION
## Summary
- clamp AddToGroupPopover horizontally so it stays within viewport on small screens
- log progress for popover overflow task and sprint note

## Testing
- `npx @biomejs/biome check src/components/AddToGroupPopover.svelte tasks/25081103-fix-popover-overflow.md tasks/25081107-SPRINT-aug-11-2025-ux-heatmap-bugs.md` *(fails: configuration schema mismatch)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689a40e738308323beed8aee6aa65abd